### PR TITLE
Feature/broken links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epdc",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "epdc",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@astrojs/mdx": "^4.2.4",
         "@astrojs/partytown": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "epdc",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/src/pages/en/services.astro
+++ b/src/pages/en/services.astro
@@ -174,7 +174,7 @@ const structuredData = {
       buttonLabel="Crafted With Love"
       buttonHref="/en/crafted-with-love/" 
       imgSrc={caseStudyImage}
-      imgAlt="FishCostaRica.com"
+      imgAlt="Avalanche Advertising - White-label Partner"
     />
   </section>
 

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -154,7 +154,7 @@ const process = [
       quote="Construimos una tienda de comercio electrónico a medida para indumentaria médica y estudiantil, y continuamos optimizándola a través de nuestro plan de mantenimiento mensual. Utilizamos herramientas de IA para escribir mejores descripciones de productos y elegir las palabras clave adecuadas, ayudando al sitio a mantenerse por delante de los competidores en los resultados de búsqueda. ¿El resultado? Mayor visibilidad, experiencias de compra más fluidas y un crecimiento constante de las ventas, todo sin la molestia de gestionar la tecnología."
       author="MonkeyScrubs, Cliente de eCommerce + Plan de Soporte"
       buttonLabel="Caso de Estudio"
-      buttonHref="es/crafted-with-love/monkeyscrubs-es/" 
+      buttonHref="/es/crafted-with-love/monkeyscrubs-es/" 
       imgSrc={caseStudyImage}
       imgAlt="Tienda eCommerce MonkeyScrubs mostrada en dispositivo móvil"
     />

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -154,7 +154,7 @@ const process = [
       quote="Construimos una tienda de comercio electrónico a medida para indumentaria médica y estudiantil, y continuamos optimizándola a través de nuestro plan de mantenimiento mensual. Utilizamos herramientas de IA para escribir mejores descripciones de productos y elegir las palabras clave adecuadas, ayudando al sitio a mantenerse por delante de los competidores en los resultados de búsqueda. ¿El resultado? Mayor visibilidad, experiencias de compra más fluidas y un crecimiento constante de las ventas, todo sin la molestia de gestionar la tecnología."
       author="MonkeyScrubs, Cliente de eCommerce + Plan de Soporte"
       buttonLabel="Caso de Estudio"
-      buttonHref="/es/crafted-with-love/monkeyscrubs-es/" 
+      buttonHref="/es/crafted-with-love/monkey-scrubs-ecommerce-es/" 
       imgSrc={caseStudyImage}
       imgAlt="Tienda eCommerce MonkeyScrubs mostrada en dispositivo móvil"
     />

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -167,7 +167,7 @@ const process = [
   </section>
 
   <section class={styles.cta} aria-label="Llamada a la Acción de Contacto">
-    <Button href="/contact" label="Hablemos" />
+    <Button href="/es/contact" label="Hablemos" />
   </section>
 </Layout>
 <script type="module" is:inline>

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -59,7 +59,7 @@ const process = [
   <section class={styles.about} aria-label="Sobre Nosotros">
     <p>Somos <span class={styles.accent}>ElPuas Digital Crafts</span> — un estudio web familiar que construye sitios web de alto rendimiento con amor, código y café.</p>
 
-    <p>Creemos que los grandes sitios web van más allá del diseño. Deben ser ultrarrápidos, fáciles de gestionar y listos para crecer con tu negocio. Por eso utilizamos frameworks modernos como <span class={styles.accent}>Astro</span>, soluciones inteligentes de <span class={styles.accent}>WordPress</span> y flujos de trabajo <span class={styles.accent}>asistidos por IA</span> para entregar sitios artesanales sin el alto costo de mantenimiento.</p>
+    <p>Creemos que los grandes sitios web van más allá del diseño. Deben ser ultrarrápidos, fáciles de gestionar y listos para crecer con tu negocio. Por eso utilizamos frameworks modernos como <span class={styles.accent}>Astro</span>, soluciones inteligentes de <span class={styles.accent}>WordPress</span> y flujos de trabajo <span class={styles.accent}>asistidos por IA</span> para entregar sitios web de alto rendimiento sin el alto costo de mantenimiento.</p>
 
     <p>Desde desarrollos personalizados de <span class={styles.accent}>WordPress</span> hasta plataformas optimizadas de <span class={styles.accent}>eCommerce</span>, creamos experiencias digitales que ayudan a crecer a pequeñas empresas y a escalar agencias. Ya sea que estés lanzando tu primer sitio o necesites un socio confiable de marca blanca, te respaldamos con comunicación clara, ejecución cuidadosa y soporte a largo plazo que realmente está presente.</p>
 

--- a/src/pages/es/services.astro
+++ b/src/pages/es/services.astro
@@ -119,7 +119,7 @@ const structuredData = {
           'Canal dedicado de Slack para emergencias',
           'Diseño web + soporte',
           'Mantenimiento básico',
-          'Monitoreo de email y tiempo de actividad'
+          'Monitoreo de tiempo de actividad'
         ]}
       />
 

--- a/src/pages/es/services.astro
+++ b/src/pages/es/services.astro
@@ -171,10 +171,10 @@ const structuredData = {
       accentText="Apoyamos a agencias y estudios a través de una ejecución confiable con marca blanca."
       quote="Trabajar con ElPuas ha sido un cambio de juego. Entregan constantemente trabajo de alta calidad a tiempo, manejan especificaciones técnicas complejas con facilidad y elevan la calidad del resultado de nuestra agencia. Nuestros clientes están contentos — y eso nos hace lucir genial."
       author="Avalanche Advertising (Socio White-label)"
-      buttonLabel="Caso de Estudio"
-      buttonHref="/es/crafted-with-love/fishcostarica-tourism-es/" 
+      buttonLabel="Hecho con Amor"
+      buttonHref="/es/crafted-with-love/" 
       imgSrc={caseStudyImage}
-      imgAlt="FishCostaRica.com"
+      imgAlt="Avalanche Advertising - White-label Partner"
     />
   </section>
 

--- a/src/pages/es/services.astro
+++ b/src/pages/es/services.astro
@@ -174,7 +174,7 @@ const structuredData = {
       buttonLabel="Hecho con Amor"
       buttonHref="/es/crafted-with-love/" 
       imgSrc={caseStudyImage}
-      imgAlt="Avalanche Advertising - White-label Partner"
+      imgAlt="Avalanche Advertising - Socio de marca blanca"
     />
   </section>
 

--- a/src/pages/it/about.astro
+++ b/src/pages/it/about.astro
@@ -154,7 +154,7 @@ const process = [
       quote="Abbiamo costruito un negozio e-commerce su misura per abbigliamento medico e studenti, e continuiamo a ottimizzarlo attraverso il nostro piano di manutenzione mensile. Utilizziamo strumenti di IA per scrivere descrizioni di prodotti migliori e scegliere le parole chiave giuste, aiutando il sito a rimanere davanti ai concorrenti nei risultati di ricerca. Il risultato? Maggiore visibilità, esperienze di acquisto più fluide e una crescita costante delle vendite — tutto senza il fastidio di gestire la tecnologia."
       author="MonkeyScrubs, Cliente eCommerce + Piano di Supporto"
       buttonLabel="Caso Studio"
-      buttonHref="/it/crafted-with-love/monkeyscrubs-es/" 
+      buttonHref="/it/crafted-with-love/monkey-scrubs-ecommerce-it/" 
       imgSrc={caseStudyImage}
       imgAlt="Negozio eCommerce MonkeyScrubs mostrato su dispositivo mobile"
     />

--- a/src/pages/it/about.astro
+++ b/src/pages/it/about.astro
@@ -167,7 +167,7 @@ const process = [
   </section>
 
   <section class={styles.cta} aria-label="Call to Action di Contatto">
-    <Button href="/contact" label="Parliamone" />
+    <Button href="/it/contact" label="Parliamone" />
   </section>
 </Layout>
 <script type="module" is:inline>

--- a/src/pages/it/about.astro
+++ b/src/pages/it/about.astro
@@ -154,7 +154,7 @@ const process = [
       quote="Abbiamo costruito un negozio e-commerce su misura per abbigliamento medico e studenti, e continuiamo a ottimizzarlo attraverso il nostro piano di manutenzione mensile. Utilizziamo strumenti di IA per scrivere descrizioni di prodotti migliori e scegliere le parole chiave giuste, aiutando il sito a rimanere davanti ai concorrenti nei risultati di ricerca. Il risultato? Maggiore visibilità, esperienze di acquisto più fluide e una crescita costante delle vendite — tutto senza il fastidio di gestire la tecnologia."
       author="MonkeyScrubs, Cliente eCommerce + Piano di Supporto"
       buttonLabel="Caso Studio"
-      buttonHref="#" 
+      buttonHref="/it/crafted-with-love/monkeyscrubs-es/" 
       imgSrc={caseStudyImage}
       imgAlt="Negozio eCommerce MonkeyScrubs mostrato su dispositivo mobile"
     />

--- a/src/pages/it/index.astro
+++ b/src/pages/it/index.astro
@@ -69,7 +69,7 @@ const lang = 'it';
     quote="Dal lancio del nuovo sito, abbiamo visto un notevole incremento nelle prenotazioni e una migliore visibilità nelle ricerche. ElPuas ha compreso i nostri obiettivi e ha fornito risultati."
     author="Richard Krug, FishCostaRica.com"
     buttonLabel="Caso Studio"
-    buttonHref="it/crafted-with-love/fishcostarica-tourism-it/" 
+    buttonHref="/it/crafted-with-love/fishcostarica-tourism-it/" 
     imgSrc={caseStudyImage}
     imgAlt="FishCostaRica.com"
   />

--- a/src/pages/it/services.astro
+++ b/src/pages/it/services.astro
@@ -171,10 +171,10 @@ const structuredData = {
       accentText="Supportiamo agenzie e studi attraverso un'esecuzione affidabile in white-label."
       quote="Lavorare con ElPuas è stato un punto di svolta. Consegnano costantemente lavoro di alta qualità nei tempi previsti, gestiscono specifiche tecniche complesse con facilità e migliorano la qualità dell'output della nostra agenzia. I nostri clienti sono felici — e questo ci fa apparire al meglio."
       author="Avalanche Advertising (Partner White-label)"
-      buttonLabel="Caso Studio"
-      buttonHref="#" 
+      buttonLabel="Creato con Amore"
+      buttonHref="/it/crafted-with-love/" 
       imgSrc={caseStudyImage}
-      imgAlt="FishCostaRica.com"
+      imgAlt="Avalanche Advertising - White-label Partner"
     />
   </section>
 

--- a/src/pages/it/services.astro
+++ b/src/pages/it/services.astro
@@ -174,7 +174,7 @@ const structuredData = {
       buttonLabel="Creato con Amore"
       buttonHref="/it/crafted-with-love/" 
       imgSrc={caseStudyImage}
-      imgAlt="Avalanche Advertising - White-label Partner"
+      imgAlt="Avalanche Advertising - Partner White-label"
     />
   </section>
 


### PR DESCRIPTION
This pull request includes updates across multiple language-specific pages and metadata files to improve consistency, fix links, and refine content. Key changes involve updating version numbers, adjusting button labels and hrefs, improving alt text for images, and refining descriptions for clarity and accuracy.

### Metadata Updates:
* Updated `version` in `package.json` from `1.1.1` to `1.1.2`.

### Content Refinements:
* Refined Spanish text in `src/pages/es/about.astro` to specify "sitios web de alto rendimiento" instead of "sitios artesanales" for clarity.
* Updated Italian text in `src/pages/it/services.astro` to change button label from "Caso Studio" to "Creato con Amore" and adjusted image alt text to "Avalanche Advertising - White-label Partner".

### Link Fixes and Adjustments:
* Fixed broken or incomplete `buttonHref` links across Spanish and Italian pages, ensuring proper paths for case studies and contact pages. Examples include `/es/crafted-with-love/monkey-scrubs-ecommerce-es/` and `/it/contact`. [[1]](diffhunk://#diff-fd2b978fba3005e3db2ca22a95a886fe671df971be45f0e9b30f31373b1e198fL157-R157) [[2]](diffhunk://#diff-82c4c6b2feea6409aedcd4353363ff706f95beb0b7360d4e97e4910511fe2d1dL157-R157) [[3]](diffhunk://#diff-dcb563200b82cab925edbe626d4e92784f4c0972fb7e7e417d9718e9878dbb23L72-R72)
* Updated `buttonHref` in Spanish services page to point to `/es/crafted-with-love/` instead of a specific case study.

### Accessibility Improvements:
* Improved alt text for images across Spanish and Italian pages to better describe the content, e.g., "Avalanche Advertising - White-label Partner". [[1]](diffhunk://#diff-2d7960e7bc67c0d501b273ca1e408195f3bac17a170686293705327b8e0e0f35L177-R177) [[2]](diffhunk://#diff-64a92239b157396ff96bf2417921ad2970dd48a563fab6ef6bbfd274409bcf74L174-R177)

These changes enhance the user experience by ensuring consistency, improving navigation, and refining content for clarity and accessibility.