### PR TITLE
Develop

### DIFF
--- a/.context/2026-06-03-blog-single-duplicate-hero-image-hotfix.md
+++ b/.context/2026-06-03-blog-single-duplicate-hero-image-hotfix.md
@@ -12,6 +12,7 @@
 - Changed hero rendering from implicit behavior to explicit behavior through `showHeroImage`.
 - Preserved the Labs-only metadata block (`tags` before hero) behind `contentType === 'labs'`.
 - Preserved Open Graph and structured-data image support by continuing to resolve the social image from `featuredImage ?? image`.
+- Updated every Labs single route to opt into the shared hero explicitly with `showHeroImage={true}` while continuing to pass `featuredImage`.
 
 ## Blog Vs Labs Separation Decision
 
@@ -23,10 +24,18 @@
   - the layout can inject the hero only when `showHeroImage` is set
 - This avoids CSS hiding, duplicate conditions across pages, or splitting the shared shell into near-duplicate layouts.
 
+## Why Labs Hero Disappeared
+
+- The blog hotfix correctly changed shared hero rendering from implicit to explicit.
+- Labs single pages were already passing the correct `featuredImage`, but they were not updated to opt into the new explicit hero behavior.
+- That left social metadata intact, because the shared layout still resolved `ogImage` from `featuredImage`, but the visible Labs hero stopped rendering.
 ## Regression Fix Details
 
 - Updated `src/layouts/BlogPost.astro` to:
   - support shared blog/labs metadata props
   - preserve social metadata and structured data for both content types
   - render the shared hero image only when `showHeroImage` is explicitly enabled
-- On the current production snapshot in this workspace, the Labs route files are not present on `main`, so the hotfix was applied at the shared layout boundary where the regression was introduced.
+- Updated the Labs single route callers to pass `showHeroImage={true}` so:
+  - blog posts keep their MDX-authored single hero
+  - Labs pages render one shared hero from `featuredImage`
+  - the tags block remains below the title and above the hero

--- a/.context/2026-06-03-blog-single-duplicate-hero-image-hotfix.md
+++ b/.context/2026-06-03-blog-single-duplicate-hero-image-hotfix.md
@@ -1,0 +1,32 @@
+# Blog Single Duplicate Hero Image Hotfix
+
+## Root Cause Analysis
+
+- The EPDC Labs refactor expanded `src/layouts/BlogPost.astro` so the shared layout could render a featured hero image for Labs entries.
+- Standard blog posts already place their lead image inside the MDX body with custom composition.
+- Once the shared layout started auto-rendering `image` / `featuredImage` ahead of `<slot />`, blog singles rendered the featured image twice: once from the layout and once from the MDX content.
+
+## Layout And Template Adjustments
+
+- Kept `BlogPost.astro` as the shared single-entry shell for metadata, headings, and structured data.
+- Changed hero rendering from implicit behavior to explicit behavior through `showHeroImage`.
+- Preserved the Labs-only metadata block (`tags` before hero) behind `contentType === 'labs'`.
+- Preserved Open Graph and structured-data image support by continuing to resolve the social image from `featuredImage ?? image`.
+
+## Blog Vs Labs Separation Decision
+
+- Blog entries keep their original composition model:
+  - title and date/author from the layout
+  - lead image and custom body composition from MDX
+- Labs entries keep the shared featured-image slot:
+  - tags render before the hero
+  - the layout can inject the hero only when `showHeroImage` is set
+- This avoids CSS hiding, duplicate conditions across pages, or splitting the shared shell into near-duplicate layouts.
+
+## Regression Fix Details
+
+- Updated `src/layouts/BlogPost.astro` to:
+  - support shared blog/labs metadata props
+  - preserve social metadata and structured data for both content types
+  - render the shared hero image only when `showHeroImage` is explicitly enabled
+- On the current production snapshot in this workspace, the Labs route files are not present on `main`, so the hotfix was applied at the shared layout boundary where the regression was introduced.

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,206 +1,199 @@
 ---
-import { Image } from "astro:assets";
-import BaseHead from "../components/BaseHead.astro";
-import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
-import FormattedDate from "../components/FormattedDate.astro";
-import StructuredData from "../components/StructuredData.astro";
-import type { Language } from "../i18n/utils";
-import "../styles/global.css";
-import stylesBlog from "../styles/ProjectLayout.module.css";
-import styles from "../styles/Layout.module.css";
+import { Image } from 'astro:assets';
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import FormattedDate from '../components/FormattedDate.astro';
+import StructuredData from '../components/StructuredData.astro';
+import type { Language } from '../i18n/utils';
+import '../styles/global.css';
+import stylesBlog from '../styles/ProjectLayout.module.css';
+import styles from '../styles/Layout.module.css';
 
 interface Props {
-  title: string;
-  description?: string;
-  excerpt?: string;
-  date?: Date;
-  publishedAt?: Date;
-  author?: string;
-  lang?: Language;
-  image?: string;
-  featuredImage?: string;
-  contentType?: "blog" | "labs";
-  entryPath?: string;
-  tags?: string[];
-  github?: string;
-  demoUrl?: string;
+	title: string;
+	description?: string;
+	excerpt?: string;
+	date?: Date;
+	publishedAt?: Date;
+	author?: string;
+	lang?: Language;
+	image?: string;
+	featuredImage?: string;
+	contentType?: 'blog' | 'labs';
+	entryPath?: string;
+	tags?: string[];
+	github?: string;
+	demoUrl?: string;
+	showHeroImage?: boolean;
 }
 
 const {
-  title,
-  description = "",
-  excerpt = "",
-  date,
-  publishedAt,
-  author,
-  lang = "en" as Language,
-  image,
-  featuredImage,
-  contentType = "blog",
-  entryPath,
-  tags = [],
-  github,
-  demoUrl,
+	title,
+	description = '',
+	excerpt = '',
+	date,
+	publishedAt,
+	author = 'ElPuas Digital Crafts',
+	lang = 'en' as Language,
+	image,
+	featuredImage,
+	contentType = 'blog',
+	entryPath,
+	tags = [],
+	showHeroImage = false,
 } = Astro.props as Props;
 
 const pubDate = publishedAt ?? date;
 const summary = excerpt || description;
 const heroImage = featuredImage ?? image;
 const absoluteHeroImage = heroImage
-  ? new URL(heroImage, Astro.site ?? Astro.url).toString()
-  : undefined;
-const schemaType = contentType === "labs" ? "TechArticle" : "Article";
+	? new URL(heroImage, Astro.site ?? Astro.url).toString()
+	: undefined;
+const schemaType = contentType === 'labs' ? 'TechArticle' : 'Article';
 const resolvedEntryPath = entryPath ?? Astro.url.pathname;
-const isLabsEntry = contentType === "labs";
+const isLabsEntry = contentType === 'labs';
 
 const data = {
-  "@context": "https://schema.org",
-  "@type": schemaType,
-  headline: title,
-  description: summary,
-  ...(author && {
-    author: {
-      "@type": "Organization",
-      name: author,
-    },
-  }),
-  ...(pubDate && {
-    datePublished: pubDate.toISOString(),
-  }),
-  inLanguage: lang,
-  ...(tags.length > 0 && {
-    keywords: tags.join(", "),
-  }),
-  ...(heroImage && {
-    image: {
-      "@type": "ImageObject",
-      url: absoluteHeroImage,
-      width: 1200,
-      height: 630,
-    },
-  }),
-  mainEntityOfPage: {
-    "@type": "WebPage",
-    "@id": `https://elpuasdigitalcrafts.com${resolvedEntryPath}`,
-  },
+	'@context': 'https://schema.org',
+	'@type': schemaType,
+	headline: title,
+	description: summary,
+	...(author && {
+		author: {
+			'@type': 'Organization',
+			name: author,
+		},
+	}),
+	...(pubDate && {
+		datePublished: pubDate.toISOString(),
+	}),
+	inLanguage: lang,
+	...(tags.length > 0 && {
+		keywords: tags.join(', '),
+	}),
+	...(heroImage && {
+		image: {
+			'@type': 'ImageObject',
+			url: absoluteHeroImage,
+			width: 1200,
+			height: 630,
+		},
+	}),
+	mainEntityOfPage: {
+		'@type': 'WebPage',
+		'@id': `https://elpuasdigitalcrafts.com${resolvedEntryPath}`,
+	},
 };
 ---
-
-<!doctype html>
+<!DOCTYPE html>
 <html lang={lang}>
-  <head>
-    <BaseHead title={title} description={summary} ogImage={heroImage} />
-    <StructuredData {data} />
-  </head>
+	<head>
+		<BaseHead title={title} description={summary} ogImage={heroImage} />
+		<StructuredData {data} />
+	</head>
 
-  <body>
-    <header>
-      <div class:list={styles.wrapper}>
-        <Header lang={lang} />
-      </div>
-    </header>
-    <main>
-      <article class:list={stylesBlog.article}>
-        <div class="prose" class:list={stylesBlog.prose}>
-          <div class="title">
-            <h1>{title}</h1>
-            {
-              !isLabsEntry && (pubDate || author) && (
-                <div class="blog-date">
-                  <FormattedDate date={pubDate} />
-                  {author && (
-                    <p>
-                      By <span class="accent">{author}</span>
-                    </p>
-                  )}
-                </div>
-              )
-            }
-          </div>
-          {
-            isLabsEntry && tags.length > 0 && (
-              <div class="entry-meta" aria-label="Entry metadata">
-                <div class="entry-tags">
-                  {tags.map((tag) => (
-                    <span class="entry-tag">{tag}</span>
-                  ))}
-                </div>
-              </div>
-            )
-          }
-          {
-            heroImage && (
-              <div class="blog-hero-image">
-                <Image src={heroImage} alt={title} width={1280} height={720} />
-              </div>
-            )
-          }
-          <slot />
-        </div>
-      </article>
-    </main>
-    <footer>
-      <div class:list={styles.wrapper}>
-        <Footer lang={lang} />
-      </div>
-    </footer>
-    <script>
-      // Black and White Theme Toggle with Persistence
-      document.addEventListener("DOMContentLoaded", () => {
-        const bwToggle = document.getElementById("bw-toggle");
-        const html = document.documentElement;
+	<body>
+		<header>
+			<div class:list={styles.wrapper}>
+				<Header lang={lang} />
+			</div>
+		</header>
+		<main>
+			<article class:list={stylesBlog.article}>
+				<div class="prose" class:list={stylesBlog.prose}>
+					<div class="title">
+						<h1>{title}</h1>
+						{
+							!isLabsEntry && (pubDate || author) && (
+								<div class="blog-date">
+									{pubDate && <FormattedDate date={pubDate} />}
+									{author && <p>By <span class="accent">{author}</span></p>}
+								</div>
+							)
+						}
+					</div>
+					{
+						isLabsEntry && tags.length > 0 && (
+							<div class="entry-meta" aria-label="Entry metadata">
+								<div class="entry-tags">
+									{tags.map((tag) => (
+										<span class="entry-tag">{tag}</span>
+									))}
+								</div>
+							</div>
+						)
+					}
+					{
+						showHeroImage && heroImage && (
+							<div class="blog-hero-image">
+								<Image src={heroImage} alt={title} width={1280} height={720} loading="eager" decoding="async" />
+							</div>
+						)
+					}
+					<slot />
+				</div>
+			</article>
+		</main>
+		<footer>
+			<div class:list={styles.wrapper}>
+				<Footer lang={lang} />
+			</div>
+		</footer>
+		<script>
+			// Black and White Theme Toggle with Persistence
+			document.addEventListener('DOMContentLoaded', () => {
+				const bwToggle = document.getElementById('bw-toggle');
+				const html = document.documentElement;
 
-        // Load saved theme from localStorage
-        const savedTheme = localStorage.getItem("epdc-theme");
-        if (savedTheme && (savedTheme === "light" || savedTheme === "bw")) {
-          html.setAttribute("data-theme", savedTheme);
-        }
+				// Load saved theme from localStorage
+				const savedTheme = localStorage.getItem('epdc-theme');
+				if (savedTheme && (savedTheme === 'light' || savedTheme === 'bw')) {
+					html.setAttribute('data-theme', savedTheme);
+				}
 
-        if (bwToggle) {
-          bwToggle.addEventListener("click", () => {
-            const currentTheme = html.getAttribute("data-theme");
-            const newTheme = currentTheme === "light" ? "bw" : "light";
+				if (bwToggle) {
+					bwToggle.addEventListener('click', () => {
+						const currentTheme = html.getAttribute('data-theme');
+						const newTheme = currentTheme === 'light' ? 'bw' : 'light';
 
-            // Update DOM
-            html.setAttribute("data-theme", newTheme);
+						// Update DOM
+						html.setAttribute('data-theme', newTheme);
 
-            // Save to localStorage
-            localStorage.setItem("epdc-theme", newTheme);
+						// Save to localStorage
+						localStorage.setItem('epdc-theme', newTheme);
 
-            // Update button aria-label
-            const isBlackWhite = newTheme === "bw";
-            bwToggle.setAttribute(
-              "aria-label",
-              isBlackWhite
-                ? "Switch to color mode"
-                : "Toggle black and white mode",
-            );
-          });
-        }
-      });
-    </script>
-    <style>
-      .entry-meta {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-md);
-        margin: 0 0 var(--space-2xl);
-      }
+						// Update button aria-label
+						const isBlackWhite = newTheme === 'bw';
+						bwToggle.setAttribute(
+							'aria-label',
+							isBlackWhite ? 'Switch to color mode' : 'Toggle black and white mode',
+						);
+					});
+				}
+			});
+		</script>
+		<style>
+			.entry-meta {
+				display: flex;
+				flex-direction: column;
+				gap: var(--space-md);
+				margin: 0 0 var(--space-2xl);
+			}
 
-      .entry-tags {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--space-sm);
-      }
+			.entry-tags {
+				display: flex;
+				flex-wrap: wrap;
+				gap: var(--space-sm);
+			}
 
-      .entry-tag {
-        border: 1px solid var(--color-quaternary);
-        border-radius: 999px;
-        padding: 0.35rem 0.75rem;
-        font-size: 0.9rem;
-        line-height: 1;
-      }
-    </style>
-  </body>
+			.entry-tag {
+				border: 1px solid var(--color-quaternary);
+				border-radius: 999px;
+				padding: 0.35rem 0.75rem;
+				font-size: 0.9rem;
+				line-height: 1;
+			}
+		</style>
+	</body>
 </html>

--- a/src/pages/en/epdc-labs/[slug].astro
+++ b/src/pages/en/epdc-labs/[slug].astro
@@ -24,6 +24,7 @@ const { Content } = await render(lab);
   featuredImage={lab.data.featuredImage}
   lang="en"
   contentType="labs"
+  showHeroImage={true}
   entryPath={`/en/epdc-labs/${getLabPublicSlug(lab)}`}
   tags={lab.data.tags}
   github={lab.data.github}

--- a/src/pages/epdc-labs/[slug].astro
+++ b/src/pages/epdc-labs/[slug].astro
@@ -24,6 +24,7 @@ const { Content } = await render(lab);
   featuredImage={lab.data.featuredImage}
   lang="en"
   contentType="labs"
+  showHeroImage={true}
   entryPath={`/epdc-labs/${getLabPublicSlug(lab)}`}
   tags={lab.data.tags}
   github={lab.data.github}

--- a/src/pages/es/epdc-labs/[slug].astro
+++ b/src/pages/es/epdc-labs/[slug].astro
@@ -24,6 +24,7 @@ const { Content } = await render(lab);
   featuredImage={lab.data.featuredImage}
   lang="es"
   contentType="labs"
+  showHeroImage={true}
   entryPath={`/es/epdc-labs/${getLabPublicSlug(lab)}`}
   tags={lab.data.tags}
   github={lab.data.github}

--- a/src/pages/it/epdc-labs/[slug].astro
+++ b/src/pages/it/epdc-labs/[slug].astro
@@ -24,6 +24,7 @@ const { Content } = await render(lab);
   featuredImage={lab.data.featuredImage}
   lang="it"
   contentType="labs"
+  showHeroImage={true}
   entryPath={`/it/epdc-labs/${getLabPublicSlug(lab)}`}
   tags={lab.data.tags}
   github={lab.data.github}


### PR DESCRIPTION
This pull request fixes a regression where Labs single pages stopped displaying their hero image after a layout refactor. The solution makes hero image rendering explicit through a new `showHeroImage` prop, ensuring Labs entries show the hero while blog entries retain their custom MDX image composition. The update also maintains correct metadata and avoids code duplication or unnecessary CSS workarounds.

**Layout and rendering logic improvements:**

* Updated `src/layouts/BlogPost.astro` to render the hero image only when the new `showHeroImage` prop is explicitly set, preventing duplicate hero images in standard blog posts and restoring the hero for Labs entries. Also improved prop handling and code consistency. [[1]](diffhunk://#diff-ce25bc7c3179935e67a17aea1a0d4212ea35bc8cdaa4f005a2c7999b4cbf46a7L23-R44) [[2]](diffhunk://#diff-ce25bc7c3179935e67a17aea1a0d4212ea35bc8cdaa4f005a2c7999b4cbf46a7L133-R130)
* Ensured that Labs single routes (`src/pages/epdc-labs/[slug].astro` and language variants) now pass `showHeroImage={true}` to opt into shared hero rendering for Labs pages. ([src/pages/epdc-labs/[slug].astroR27](diffhunk://#diff-c33d2909902887dc0aae976001aafba49bf47540dcaf84e7e44fd12f34b31815R27), [src/pages/en/epdc-labs/[slug].astroR27](diffhunk://#diff-813af19102d8abbbbb61524d720189fb0e7e8c702486bc346005883bca499f11R27), [src/pages/es/epdc-labs/[slug].astroR27](diffhunk://#diff-082fab241cb2a6b52deae573f745e48a350dce429d07a3679d505a8736a098d2R27), [src/pages/it/epdc-labs/[slug].astroR27](diffhunk://#diff-235089e0ed2d30e8c0fcd11fda7ac2d838eb2921b754dfd5d63e9bc2bd8fbf31R27))

**Documentation and analysis:**

* Added a detailed root cause analysis and hotfix rationale in `.context/2026-06-03-blog-single-duplicate-hero-image-hotfix.md`, explaining the background, solution, and why Labs hero images disappeared after the previous change.

**Other improvements:**

* Standardized code style, improved default prop values, and updated theme toggle script for consistency and maintainability in `BlogPost.astro`. [[1]](diffhunk://#diff-ce25bc7c3179935e67a17aea1a0d4212ea35bc8cdaa4f005a2c7999b4cbf46a7L2-R11) [[2]](diffhunk://#diff-ce25bc7c3179935e67a17aea1a0d4212ea35bc8cdaa4f005a2c7999b4cbf46a7L53-R64) [[3]](diffhunk://#diff-ce25bc7c3179935e67a17aea1a0d4212ea35bc8cdaa4f005a2c7999b4cbf46a7L73-R89) [[4]](diffhunk://#diff-ce25bc7c3179935e67a17aea1a0d4212ea35bc8cdaa4f005a2c7999b4cbf46a7L111-R111) [[5]](diffhunk://#diff-ce25bc7c3179935e67a17aea1a0d4212ea35bc8cdaa4f005a2c7999b4cbf46a7L150-R170)