### PR TITLE
Redesign EPDC Labs index cards

### DIFF
--- a/.context/2026-06-03-epdc-labs-index-cards.md
+++ b/.context/2026-06-03-epdc-labs-index-cards.md
@@ -1,0 +1,38 @@
+# EPDC Labs Index Cards Redesign
+
+## Scope Isolation
+
+- Redesigned only the `/epdc-labs` index card presentation.
+- Left Blog index pages on their existing `BlogCard.astro` plus `BlogIndex.module.css` path.
+- Left Portfolio components and styles untouched.
+
+## Shared Component Considerations
+
+- The Labs index previously used `CollectionIndexPage.astro`, which renders `BlogCard.astro`.
+- Instead of mutating that shared path, the implementation adds:
+  - `src/components/LabsIndexPage.astro`
+  - `src/components/LabsCard.astro`
+  - `src/styles/LabsIndex.module.css`
+- The four Labs index routes now import the Labs-specific page component directly, so Blog routes continue using their original card rendering stack.
+
+## Labs-Only Design Decisions
+
+- Shifted the Labs card hierarchy away from article-style image-first composition toward product/system presentation:
+  - optional status row
+  - title-first compact card structure
+  - concise technical summary
+  - tags as capability chips
+  - explicit project CTA
+- Added a localized Labs-only kicker in the dedicated index page shell instead of reusing Blog hero copy patterns.
+- Reduced image dominance by moving the preview into a secondary supporting slot.
+- Simplified the index card again after grid breakage so it now follows the same denser, cleaner structure as the Labs cards used inside post content.
+- Replaced per-entry featured images in the Labs index card with a shared generic lab icon to keep the index visually consistent and tool/system-oriented.
+- Added an optional `status` field to the Labs collection schema and populated the existing EPDC Conversations entry in all three languages with localized status copy.
+
+## How Blog Regressions Were Avoided
+
+- Did not edit `src/components/BlogCard.astro`.
+- Did not edit `src/styles/BlogIndex.module.css`.
+- Did not edit Blog index pages.
+- Did not repurpose shared Blog classes for Labs styling.
+- Kept routing logic explicit at the Labs page level so only `/epdc-labs` consumes the new card UI.

--- a/src/components/LabsCard.astro
+++ b/src/components/LabsCard.astro
@@ -1,0 +1,162 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { Icon } from 'astro-icon/components';
+import type { Language } from '../i18n/utils';
+
+interface Props {
+  lab: CollectionEntry<'labs'>;
+  lang: Language;
+  pathPrefix: string;
+}
+
+const { lab, lang, pathPrefix } = Astro.props;
+
+const {
+  title,
+  excerpt,
+  publicSlug,
+} = lab.data;
+
+const projectUrl = `${pathPrefix}/${publicSlug ?? lab.slug}`;
+---
+
+<article class="lab-card">
+  <a href={projectUrl} class="card-shell" aria-label={title}>
+    <span class="media" aria-hidden="true">
+      <Icon name="ph:flask" width="20" height="20" />
+    </span>
+
+    <div class="copy">
+      <h2 class="card-title">{title}</h2>
+      <p class="card-excerpt">{excerpt}</p>
+    </div>
+  </a>
+</article>
+
+<style>
+  .lab-card {
+    min-width: 0;
+    align-self: start;
+    opacity: 0;
+    animation: labs-card-fade-in 560ms ease forwards;
+  }
+
+  .lab-card:nth-child(2) {
+    animation-delay: 70ms;
+  }
+
+  .lab-card:nth-child(3) {
+    animation-delay: 140ms;
+  }
+
+  .lab-card:nth-child(4) {
+    animation-delay: 210ms;
+  }
+
+  .lab-card:nth-child(5) {
+    animation-delay: 280ms;
+  }
+
+  .lab-card:nth-child(6) {
+    animation-delay: 350ms;
+  }
+
+  .lab-card:nth-child(7) {
+    animation-delay: 420ms;
+  }
+
+  .lab-card:nth-child(8) {
+    animation-delay: 490ms;
+  }
+
+  .lab-card:nth-child(9) {
+    animation-delay: 560ms;
+  }
+
+  .card-shell {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: var(--space-md);
+    align-items: start;
+    padding: var(--space-md);
+    border: 1px solid var(--color-quaternary);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--color-primary) 94%, var(--color-secondary) 6%);
+    color: inherit;
+    text-decoration: none;
+    transition:
+      transform 180ms ease,
+      border-color 180ms ease,
+      background 180ms ease;
+  }
+
+  .card-shell:hover,
+  .card-shell:focus-within {
+    transform: translateY(-1px);
+    border-color: color-mix(in srgb, var(--color-secondary) 40%, var(--color-quaternary) 60%);
+    background: color-mix(in srgb, var(--color-primary) 92%, var(--color-secondary) 8%);
+  }
+
+  .copy {
+    min-width: 0;
+  }
+
+  .card-shell .card-title {
+    margin: 0 0 0.35rem;
+    font-size: clamp(1.1rem, 1rem + 0.3vw, 1.25rem);
+    font-family: 'Inter', sans-serif;
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -0.03em;
+    color: var(--color-secondary);
+  }
+
+  .card-shell .card-excerpt {
+    margin: 0;
+    font-size: 0.98rem;
+    font-family: 'Montserrat VF', sans-serif;
+    font-weight: 300;
+    line-height: 1.55;
+    color: var(--color-secondary);
+  }
+
+  .media {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 2.25rem;
+    height: 2.25rem;
+    border: 1px solid var(--color-quaternary);
+    border-radius: 8px;
+    color: var(--color-tertiary);
+  }
+
+  .media :global(svg) {
+    display: block;
+  }
+
+  .card-shell:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--color-secondary) 65%, white 35%);
+    outline-offset: 3px;
+  }
+
+  @keyframes labs-card-fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .lab-card {
+      opacity: 1;
+      animation: none;
+    }
+  }
+</style>

--- a/src/components/LabsIndexPage.astro
+++ b/src/components/LabsIndexPage.astro
@@ -1,0 +1,46 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import Layout from '../layouts/Layout.astro';
+import type { Language } from '../i18n/utils';
+import LabsCard from './LabsCard.astro';
+import styles from '../styles/LabsIndex.module.css';
+
+interface Props {
+  lang: Language;
+  pageTitle: string;
+  pageDescription: string;
+  heading: string;
+  intro: string;
+  entries: CollectionEntry<'labs'>[];
+  emptyMessage: string;
+  pathPrefix: string;
+}
+
+const {
+  lang,
+  pageTitle,
+  pageDescription,
+  heading,
+  intro,
+  entries,
+  emptyMessage,
+  pathPrefix,
+} = Astro.props;
+---
+
+<Layout title={pageTitle} description={pageDescription} lang={lang}>
+  <section class={styles.hero}>
+    <h1>{heading}</h1>
+    <p>{intro}</p>
+  </section>
+
+  {entries.length === 0 ? (
+    <p>{emptyMessage}</p>
+  ) : (
+    <div class={styles.grid}>
+      {entries.map((entry) => (
+        <LabsCard lab={entry} lang={lang} pathPrefix={pathPrefix} />
+      ))}
+    </div>
+  )}
+</Layout>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -33,6 +33,7 @@ const labsCollection = defineCollection({
   schema: z.object({
     title: z.string(),
     excerpt: z.string(),
+    status: z.string().optional(),
     publishedAt: z.coerce.date(),
     featuredImage: z.string().optional(),
     featured: z.boolean().optional().default(false),

--- a/src/content/labs/epdc-conversations.en.mdx
+++ b/src/content/labs/epdc-conversations.en.mdx
@@ -1,6 +1,7 @@
 ---
 title: "EPDC Conversations"
 excerpt: "A modern WordPress CTA and conversation system focused on WhatsApp conversions, real metrics, and custom tools built for real business needs."
+status: "Active · In progress"
 publishedAt: "2026-06-02"
 featuredImage: "/lab/epdc-conversations/lab-epdc-conversations.webp"
 featured: true

--- a/src/content/labs/epdc-conversations.es.mdx
+++ b/src/content/labs/epdc-conversations.es.mdx
@@ -1,6 +1,7 @@
 ---
 title: "EPDC Conversations"
 excerpt: "Un sistema moderno de CTAs y conversaciones para WordPress enfocado en conversiones vía WhatsApp, métricas reales y herramientas personalizadas para negocios reales."
+status: "Activo · En evolución"
 publishedAt: "2026-06-02"
 featuredImage: "/lab/epdc-conversations/lab-epdc-conversations.webp"
 featured: true

--- a/src/content/labs/epdc-conversations.it.mdx
+++ b/src/content/labs/epdc-conversations.it.mdx
@@ -1,6 +1,7 @@
 ---
 title: "EPDC Conversations"
 excerpt: "Un moderno sistema di CTA e conversazioni per WordPress, pensato per conversioni via WhatsApp, metriche reali e strumenti personalizzati per bisogni concreti."
+status: "Attivo · In evoluzione"
 publishedAt: "2026-06-02"
 featuredImage: "/lab/epdc-conversations/lab-epdc-conversations.webp"
 featured: true

--- a/src/data/labs.ts
+++ b/src/data/labs.ts
@@ -8,6 +8,7 @@ type LabsIndexCopy = {
   pageDescription: string;
   heading: string;
   intro: string;
+  kicker: string;
   emptyMessage: string;
 };
 
@@ -17,6 +18,7 @@ export const labsIndexCopy: Record<Language, LabsIndexCopy> = {
     pageDescription:
       'EPDC Labs is where ElPuas Digital Crafts documents internal tools, AI workflows, plugins, and reusable engineering systems.',
     heading: 'EPDC Labs',
+    kicker: 'Internal products, AI workflows, and engineering systems',
     intro:
       'A focused archive of internal tools, product systems, AI workflows, plugins, and reusable engineering experiments built at ElPuas Digital Crafts. Each entry is practical, technical, and grounded in implementation.',
     emptyMessage: 'No lab entries are available yet.',
@@ -26,6 +28,7 @@ export const labsIndexCopy: Record<Language, LabsIndexCopy> = {
     pageDescription:
       'EPDC Labs reúne herramientas internas, flujos de IA, plugins y sistemas reutilizables creados por ElPuas Digital Crafts.',
     heading: 'EPDC Labs',
+    kicker: 'Productos internos, flujos con IA y sistemas de ingeniería',
     intro:
       'Un archivo técnico de herramientas internas, sistemas de producto, flujos con IA, plugins y experimentos reutilizables creados en ElPuas Digital Crafts. Cada entrada parte de implementación real, no de marketing.',
     emptyMessage: 'Todavía no hay entradas en EPDC Labs.',
@@ -35,6 +38,7 @@ export const labsIndexCopy: Record<Language, LabsIndexCopy> = {
     pageDescription:
       'EPDC Labs raccoglie strumenti interni, workflow AI, plugin e sistemi riutilizzabili creati da ElPuas Digital Crafts.',
     heading: 'EPDC Labs',
+    kicker: 'Prodotti interni, workflow AI e sistemi di ingegneria',
     intro:
       'Un archivio tecnico di strumenti interni, sistemi di prodotto, workflow con IA, plugin ed esperimenti riutilizzabili creati in ElPuas Digital Crafts. Ogni voce nasce da implementazioni reali.',
     emptyMessage: 'Non ci sono ancora voci disponibili in EPDC Labs.',

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -9,6 +9,7 @@
   },
   "common": {
     "readMore": "Read More",
+    "viewProject": "View Project",
     "loading": "Loading...",
     "error": "Error",
     "welcome": "Welcome to ElPuas Digital Crafts",

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -9,6 +9,7 @@
   },
   "common": {
     "readMore": "Leer Más",
+    "viewProject": "Ver Proyecto",
     "loading": "Cargando...",
     "error": "Error",
     "welcome": "Bienvenido",

--- a/src/i18n/translations/it.json
+++ b/src/i18n/translations/it.json
@@ -9,6 +9,7 @@
   },
   "common": {
     "readMore": "Leggi di Più",
+    "viewProject": "Vedi Progetto",
     "loading": "Caricamento...",
     "error": "Errore",
     "welcome": "Benvenuto",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -15,6 +15,7 @@ type Translations = {
     };
     common: {
       readMore: string;
+      viewProject: string;
       loading: string;
       error: string;
       welcome: string;

--- a/src/pages/en/epdc-labs/index.astro
+++ b/src/pages/en/epdc-labs/index.astro
@@ -1,12 +1,12 @@
 ---
-import CollectionIndexPage from '../../../components/CollectionIndexPage.astro';
+import LabsIndexPage from '../../../components/LabsIndexPage.astro';
 import { getLabsByLanguage, labsIndexCopy } from '../../../data/labs';
 
 const labs = await getLabsByLanguage('en');
 const copy = labsIndexCopy.en;
 ---
 
-<CollectionIndexPage
+<LabsIndexPage
   lang="en"
   pageTitle={copy.pageTitle}
   pageDescription={copy.pageDescription}

--- a/src/pages/epdc-labs/index.astro
+++ b/src/pages/epdc-labs/index.astro
@@ -1,12 +1,12 @@
 ---
-import CollectionIndexPage from '../../components/CollectionIndexPage.astro';
+import LabsIndexPage from '../../components/LabsIndexPage.astro';
 import { getLabsByLanguage, labsIndexCopy } from '../../data/labs';
 
 const labs = await getLabsByLanguage('en');
 const copy = labsIndexCopy.en;
 ---
 
-<CollectionIndexPage
+<LabsIndexPage
   lang="en"
   pageTitle={copy.pageTitle}
   pageDescription={copy.pageDescription}

--- a/src/pages/es/epdc-labs/index.astro
+++ b/src/pages/es/epdc-labs/index.astro
@@ -1,12 +1,12 @@
 ---
-import CollectionIndexPage from '../../../components/CollectionIndexPage.astro';
+import LabsIndexPage from '../../../components/LabsIndexPage.astro';
 import { getLabsByLanguage, labsIndexCopy } from '../../../data/labs';
 
 const labs = await getLabsByLanguage('es');
 const copy = labsIndexCopy.es;
 ---
 
-<CollectionIndexPage
+<LabsIndexPage
   lang="es"
   pageTitle={copy.pageTitle}
   pageDescription={copy.pageDescription}

--- a/src/pages/it/epdc-labs/index.astro
+++ b/src/pages/it/epdc-labs/index.astro
@@ -1,12 +1,12 @@
 ---
-import CollectionIndexPage from '../../../components/CollectionIndexPage.astro';
+import LabsIndexPage from '../../../components/LabsIndexPage.astro';
 import { getLabsByLanguage, labsIndexCopy } from '../../../data/labs';
 
 const labs = await getLabsByLanguage('it');
 const copy = labsIndexCopy.it;
 ---
 
-<CollectionIndexPage
+<LabsIndexPage
   lang="it"
   pageTitle={copy.pageTitle}
   pageDescription={copy.pageDescription}

--- a/src/styles/LabsIndex.module.css
+++ b/src/styles/LabsIndex.module.css
@@ -1,0 +1,33 @@
+.hero {
+  display: grid;
+  gap: var(--space-lg);
+  max-width: 78ch;
+  margin-bottom: var(--space-4xl);
+}
+
+.hero h1 {
+  margin: 0;
+}
+
+.hero p:last-child {
+  max-width: 68ch;
+  margin: 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-xl);
+}
+
+@media (min-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1100px) {
+  .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
This pull request introduces a complete redesign of the `/epdc-labs` index card presentation, creating a clear separation between Labs and Blog index pages. The Labs index now uses dedicated components and styles, resulting in a product/system-focused card UI that is visually and structurally distinct from the Blog cards. The changes are fully isolated to the Labs section, preventing regressions in Blog or Portfolio areas, and include schema updates, localized copy, and accessibility improvements.

**Labs Index Redesign and Isolation**

- Introduced new Labs-specific components and styles: `LabsIndexPage.astro`, `LabsCard.astro`, and `LabsIndex.module.css`. These are now used exclusively by the four `/epdc-labs` routes, ensuring Blog and Portfolio pages remain unaffected. (.context/2026-06-03-epdc-labs-index-cards.md, [[1]](diffhunk://#diff-86c871f6b42877051c8ead99e0e8161349c953fd06c02322b061f12d6b348322R1-R162) [[2]](diffhunk://#diff-17f8959485137c7c01bebda87b18761704b9063ae259f2439429121bd2deb794R1-R46) [[3]](diffhunk://#diff-2288aec58be027d240dd7972fe63798a8f776db7e12008335c924623c414f133R1-R33)
- Updated routing in all Labs index pages to use `LabsIndexPage` instead of the shared `CollectionIndexPage`, fully decoupling Labs UI from Blog UI. [[1]](diffhunk://#diff-273a346b8c94de3b3f334b0f425867be3b372ebc726ecdfc81d0ab02405c38ccL2-R9) [[2]](diffhunk://#diff-accda71002e2c84c10e36847f850486e9696f28ce5dfa62c6612d07356af225aL2-R9) [[3]](diffhunk://#diff-52856e58997420e195b7f8a0f7b0141c05f7f9214c632a8bd0ed82d2d0ca2c01L2-R9) [[4]](diffhunk://#diff-33513bc3b1f1c5281a210a5d4fd2fa909604490e32a353fd91d7b7f658bf90f8L2-R9)

**Labs Card and Schema Enhancements**

- Created a new `LabsCard` component with a product-oriented, title-first layout, optional status row, concise summary, and a consistent lab icon instead of per-entry images.
- Added an optional `status` field to the Labs collection schema and populated it with localized values for the "EPDC Conversations" entry in all languages. [[1]](diffhunk://#diff-544dcd1cb4d05890db2dcf497052df475216a57683c346216e43133407b7ea58R36) [[2]](diffhunk://#diff-5a502ca0c3d19db7bca02d6dd1ab25c79e1256a7be798c37e45eddc2e5fc3226R4) [[3]](diffhunk://#diff-3111f43669a1811375eaac5ac02d1cc76bfeb1846fe75078fd1605ee6252c93eR4) [[4]](diffhunk://#diff-aca0238b9760307b28a659fc1254c2abe1ec2449b45b95de23936f58efe7d449R4)

**Localization and Copy Updates**

- Added a Labs-only kicker and improved intro copy in all supported languages for the Labs index, emphasizing internal products and engineering systems. [[1]](diffhunk://#diff-8df39dcb772508dbf6330ca4524bc2d2833099fa6c3a46ba7570f4aebc8775cfR11) [[2]](diffhunk://#diff-8df39dcb772508dbf6330ca4524bc2d2833099fa6c3a46ba7570f4aebc8775cfR21) [[3]](diffhunk://#diff-8df39dcb772508dbf6330ca4524bc2d2833099fa6c3a46ba7570f4aebc8775cfR31) [[4]](diffhunk://#diff-8df39dcb772508dbf6330ca4524bc2d2833099fa6c3a46ba7570f4aebc8775cfR41)
- Added and wired up a new `viewProject` translation key in English, Spanish, and Italian, with corresponding type updates. [[1]](diffhunk://#diff-b0316ff40a8c4b24e76cae45962abad74a124e09a3e7a27fa208dc4898278247R12) [[2]](diffhunk://#diff-a6e815550d3f871a5b60f6ea34e7b4d937ff70da2b3ab14651a6cb8eb6b61513R12) [[3]](diffhunk://#diff-0aab6de66792ad541b43b2bc39cc2993583951d1f12a3bf13265a6af44d903f9R12) [[4]](diffhunk://#diff-722d0924603d1d4f83e63377c2a52f9863bc7271f11aeb31b395f7aed46fac7fR18)

**Design and Accessibility Improvements**

- Implemented a denser, cleaner card grid layout with responsive breakpoints and accessible focus styles, and added staggered fade-in animations for cards. [[1]](diffhunk://#diff-86c871f6b42877051c8ead99e0e8161349c953fd06c02322b061f12d6b348322R1-R162) [[2]](diffhunk://#diff-2288aec58be027d240dd7972fe63798a8f776db7e12008335c924623c414f133R1-R33)

**Documentation**

- Added a detailed context/summary markdown file explaining the design decisions, scope isolation, and how regressions in Blog/Portfolio were avoided.